### PR TITLE
Remove stitcher from about page GraphQL query

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -67,7 +67,6 @@ export const pageQuery = graphql`
           amazon_music
           google_podcasts
           overcast
-          stitcher
           spotify
           archive
         }


### PR DESCRIPTION
Forgot to remove and it's causing Gatsby Cloud to crash